### PR TITLE
repl-env: Add precondition to ensure :session-id is string

### DIFF
--- a/src/clj/cemerick/austin.clj
+++ b/src/clj/cemerick/austin.clj
@@ -374,6 +374,8 @@ function."
                   support reflection. Defaults to \"src/\".
   "
   [& {:as opts}]
+  {:pre [(or (not (contains? opts :session-id))
+             (string? (:session-id opts)))]}
   (let [opts (merge (BrowserEnv.)
                     {:optimizations :simple
                      :working-dir   ".repl"


### PR DESCRIPTION
Using a numeric session ID (e.g. `123`) produces a URL that looks correct (e.g. `http://localhost:48240/123/repl/start`), but when used to start a REPL prints the error "Austin ClojureScript REPL session 123 does not exist."

I got bitten by this while trying to fix the URL to a constant value (my HTTP server runs in a different process so I can't easily pass the generated URL to it). The problem took me quite a while to track down. This precondition should prevent others from making the same mistake.
