### PR TITLE
Give better error message on failure of exec of external process.

### DIFF
--- a/src/clj/cemerick/austin.clj
+++ b/src/clj/cemerick/austin.clj
@@ -413,7 +413,7 @@ function."
       (set! process (try
                       (.. Runtime getRuntime (exec command))
                       (catch Exception e
-                        (throw (RuntimeException.
+                        (throw (java.io.IOException.
                                 (str "Failed to exec \"" (clojure.string/join " " command) "\"\n"
                                      "Error was:\n  " (.getMessage e) "\n")))))))
     this)


### PR DESCRIPTION
Give a more descriptive error message when exec fails. This is especially relevant for new users who might not have installed phantomjs.  The new error message looks like

```
RuntimeException Failed to exec "phantomjs /tmp/phantomjs_repl1741793749885789949.js http://localhost:55066/4710/repl/start"
Error was:
  Cannot run program "phantomjs": error=2, No such file or directory
  cemerick.austin.DelegatingExecEnv/fn--2313 (austin.clj:418)
```

previously, the message had been just

```
IOException error=2, No such file or directory  java.lang.UNIXProcess.forkAndExec (UNIXProcess.java:-2)
```
