### PR TITLE
Update BrowserEnv to include inline sourcemaps

### DIFF
--- a/src/clj/cemerick/austin.clj
+++ b/src/clj/cemerick/austin.clj
@@ -337,7 +337,8 @@ function."
                (-> (into {} opts)
                    ; TODO why isn't the :working-dir option for the brepl env
                    ; called :output-dir in the first place?
-                   (assoc :output-dir (:working-dir opts)))))
+                   (assoc :output-dir (:working-dir opts))
+                   (dissoc :source-map))))
 
 (defn- create-client-js-file [opts file-path]
   (let [file (io/file file-path)]
@@ -390,6 +391,7 @@ function."
                        :static-dir    ["." "out/"]
                        :preloaded-libs   []
                        :src           "src/"
+                       :source-map    true
                        :session-id (str (rand-int 9999))
                        ::env/compiler env/*compiler*}
                       opts)


### PR DESCRIPTION
Also dissoc :source-map from the cljsc/build call
as newer cljs version require :output-dir to line up
correctly with other flags when it is there, and do
we really need sourcemaps for the client-js?
#### Probably also want to up the version numbers in project.clj based on cljs w/ inline sourcemaps and piggieback updates.
