### PR TITLE
add note on :none not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,10 @@ ways to go about it:
 * explicitly start Austin's server, providing the desired port number, e.g.
   `(cemerick.austin/start-server 9000)`.
 
+#### Limitations
+
+* cljsbuild `:none` optimization option is not supported
+
 ## TODO
 
 * ISO a reasonable automated test strategy


### PR DESCRIPTION
added a limitations paragraph with the note abut austin not supporting :none option in cljsbuild. 
