### PR TITLE
Use with-open in handle-request to close the reader.

### DIFF
--- a/src/clj/cemerick/austin.clj
+++ b/src/clj/cemerick/austin.clj
@@ -279,9 +279,10 @@ function."
         "GET" (handle-get {:path static-path
                            :session-id session-id
                            :http-exchange req})
-        "POST" (handle-post (assoc (-> req .getRequestBody io/reader slurp read-string)
-                                   :http-exchange req
-                                   :session-id session-id)))
+        "POST" (handle-post (with-open [reader (-> req .getRequestBody io/reader)]
+                              (assoc (-> reader slurp read-string)
+                                :http-exchange req
+                                :session-id session-id))))
       (catch Throwable t (.printStackTrace t)))))
 
 (defn- browser-eval


### PR DESCRIPTION
Hi Chas,

while tracking down my "too many open files" issue I also found
one issue in austin. Would you like to merge this?

Thanks, Roman.
