### PR TITLE
update cljs-dependency to 0.0-2356

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ listed in e.g. `:source-paths` and/or `:test-source-paths` in order for
 ClojureScript source files to be picked up properly.  i.e. just having them
 enumerated in your lein-cljsbuild configuration(s) is not sufficient.
 
-**Note that Austin requires ClojureScript `0.0-2199` or higher.**
+**Note that Austin requires ClojureScript `0.0-2356` or higher.**
 
 Austin contains some Leiningen middleware that does the following:
 

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :min-lein-version "2.0.0"
   :source-paths ["src/clj"]
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.clojure/clojurescript "0.0-2227"]
+                 [org.clojure/clojurescript "0.0-2356"]
                  [com.cemerick/piggieback "0.1.3"]]
 
   :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}

--- a/src/clj/cemerick/austin.clj
+++ b/src/clj/cemerick/austin.clj
@@ -318,7 +318,7 @@ function."
     (swap! sessions update-in [(:session-id this) :*out*] (constantly *out*))
     (require 'cljs.repl.reflect)
     (repl/analyze-source (:src this))
-    (comp/with-core-cljs))
+    (comp/with-core-cljs nil (fn [])))
   (-evaluate [this _ _ js] (browser-eval (:session-id this) js))
   (-load [this ns url] (load-javascript this ns url))
   (-tear-down [this]


### PR DESCRIPTION
A set of changes to be made in order to be compatible with the latest ClojureScript version.

Tested by installing locally and trying out phantomjs and browser-repl connections on a small project.
