### PR TITLE
Fix compability issue #75 with newer piggieback version when doing "exec".

### DIFF
--- a/src/clj/cemerick/austin/repls.clj
+++ b/src/clj/cemerick/austin/repls.clj
@@ -46,7 +46,7 @@ on load.  See `browser-repl-env` docs for more."
 environment (i.e. whether nREPL is being used or not, respectively)."
   [repl-env & options]
  (if (thread-bound? #'nrepl-eval/*msg*)
-    (apply pb/cljs-repl :repl-env repl-env options)
+    (apply pb/cljs-repl repl-env options)
     (apply cljs.repl/repl repl-env options)))
 
 (defn exec


### PR DESCRIPTION
There was an issue when trying to start browser-connected repl:
 [{:type java.lang.IllegalArgumentException
   :message "No value supplied for key: cemerick.austin.DelegatingExecEnv@1d1e650e"
   :at [clojure.lang.PersistentHashMap create "PersistentHashMap.java" 77]}]
 :trace
 [[clojure.lang.PersistentHashMap create "PersistentHashMap.java" 77]
  [cemerick.piggieback$cljs_repl invokeStatic "piggieback.clj" 212]
  [cemerick.piggieback$cljs_repl doInvoke "piggieback.clj" 212]
  [clojure.lang.RestFn applyTo "RestFn.java" 139]
  [clojure.core$apply invokeStatic "core.clj" 650]
  [clojure.core$apply invoke "core.clj" 641]
  [cemerick.austin.repls$cljs_repl invokeStatic "repls.clj" 49]
  [cemerick.austin.repls$cljs_repl doInvoke "repls.clj" 43]

See https://github.com/cemerick/austin/issues/75.